### PR TITLE
WP 3.8 already put the submit button there.

### DIFF
--- a/inc/match.class.php
+++ b/inc/match.class.php
@@ -24,7 +24,7 @@ final class WCMF_match extends WCMF_base
 	}
 
 	/**
-	 * Retornando string vazia, pois o WP já coloca o botão de submit
+	 * WP 3.8 already put the submit button there.
 	 * @return string
 	 */
 	public function get_markup()


### PR DESCRIPTION
I just returned a empty string on get_markup(), but a cleanner way is to remove the call to this method.
